### PR TITLE
Feat/issue 24 11ty static website

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,19 @@
+const GIGSBOAT_INPUT_DIR = 'gigsboat-eleventy-starter'
+const GIGSBOAT_OUTPUT_DIR = 'docs' // For easy deployment to github pages
+
+module.exports = function(eleventyConfig) {
+  const markdownIt = require('markdown-it')
+  const options = {
+    html: true,
+  }
+
+  eleventyConfig.setLibrary('md', markdownIt(options).use(require('markdown-it-anchor'), { permalink: false, }))
+  eleventyConfig.addPassthroughCopy(`${GIGSBOAT_INPUT_DIR}/styles.css`)
+
+  return {
+    dir: {
+      input: GIGSBOAT_INPUT_DIR,
+      output: GIGSBOAT_OUTPUT_DIR,
+    }
+  }
+}

--- a/.github/workflows/eleventy.yml
+++ b/.github/workflows/eleventy.yml
@@ -1,0 +1,36 @@
+name: Create gigs w eleventy
+
+on:
+  [push, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install estherixz:gigsboat and 11ty dependencies
+        run: npm i -D git@github.com:estherixz/gigsboat-cli.git#feat/issue-24-11ty-static-website markdown-it markdown-it-anchor
+
+      - name: Create gigs markdown
+        run: npx gigsboat/cli --eleventy
+      - name: Create gigs html with 11ty
+        run: npx @11ty/eleventy
+
+      - name: Push gigs into repository README
+        uses: github-actions-x/commit@v2.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: 'feat/issue-24-11ty-static-website'
+          commit-message: 'chore: updating README with new gigs and create HTML'
+          files: docs/ gigsboat-eleventy-starter/
+          name: Esther Saimpou

--- a/.github/workflows/eleventy.yml
+++ b/.github/workflows/eleventy.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm i -D git@github.com:estherixz/gigsboat-cli.git#feat/issue-24-11ty-static-website markdown-it markdown-it-anchor
 
       - name: Create gigs markdown
-        run: npx gigsboat/cli --eleventy
+        run: npx gigsboat/cli
       - name: Create gigs html with 11ty
         run: npx @11ty/eleventy
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Create gigs
 on:
   push:
     branches: [main, master]
+    paths: 'pages/**'
 
 jobs:
   build:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-cayman
+theme: jekyll-theme-time-machine

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-time-machine
+theme: jekyll-theme-hacker

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>This is the html page title</title>
+    
+    <meta name="description" content="This is the html page description" />
+    
+
+    <link rel="stylesheet" href="styles.css" />
+
+</head>
+
+<body>
+    <main>
+        
+        <!-- DO NOT EDIT! THIS FILE WILL BE OVERRIDDEN BY THE GIGSBOAT SCRIPT -->
+<div align='center'><p><img src="https://img.shields.io/badge/total-1-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-1-red?style=flat-square" alt="Total Conferences">    </p>
+</div>
+  <p align='center'><h1 align='center'>This will appear at the top of the generated README.md file</h1>
+<p align='center'>Let's add some badges! <p align='center'><a href='https://twitter.com/liran_tal'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/liran_tal?style=social'></a></p>
+<ul>
+<li>In addition to raw HTML elements, you can use format sections</li>
+<li>Using HTML elements to construct the output</li>
+</ul>
+<h1 id="table-of-contents" tabindex="-1">Table of Contents</h1>
+<ul>
+<li><a href="#2021">Year of 2021</a> - total events 1</li>
+</ul>
+<h1 id="2021" tabindex="-1">2021</h1>
+<p><img src="https://img.shields.io/badge/total-1-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-1-red?style=flat-square" alt="Total Conferences"></p>
+<table>
+  <tr>
+    <td align="center"> <img src="https://pbs.twimg.com/media/E61MqWJXoAMJdHM?format=jpg&name=4096x4096" width="85" height="50" /> </td>
+  </tr>
+</table>
+<table>
+<thead>
+<tr>
+<th>Date</th>
+<th>Event</th>
+<th>Title</th>
+<th>Slides</th>
+<th>Recording</th>
+<th>Location</th>
+<th>Language</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2021-7-21</td>
+<td>Cyber Week</td>
+<td><a href="pages/2021/2021-01-01.md">Are We Forever Doomed By Software Supply Chain Risks?</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=x74sMCaZKbg&amp;ab_channel=Snyk">Recording</a></td>
+<td>IL</td>
+<td>English</td>
+</tr>
+</tbody>
+</table>
+<p align='center'><h1 align='center'>This will appear at the bottom of the generated README.md file</h1>
+<p><i>Updated on 2022-01-26T12:45:15.791Z</i></p>
+
+        
+    </main>
+</body>
+
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
 </tbody>
 </table>
 <p align='center'><h1 align='center'>This will appear at the bottom of the generated README.md file</h1>
-<p><i>Updated on 2022-01-26T12:45:15.791Z</i></p>
+<p><i>Updated on 2022-01-26T15:53:06.189Z</i></p>
 
         
     </main>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,65 @@
+:root {
+  --nightrider-gray: #333;
+  --white-smoke: #eee;
+  --blue: #0ff;
+  --cornflower-blue: #539bf5;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: var(--white-smoke);
+    --color-text: var(--nightrider-gray);
+    --color-link: var(--cornflower-blue);
+  }
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: var(--nightrider-gray);
+    --color-text: var(--white-smoke);
+    --color-link: var(--cornflower-blue);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, system-ui, sans-serif;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+}
+
+main {
+  max-width: calc(900px - (20px * 2));
+  margin: 0 auto;
+  padding-right: 20px;
+  padding-left: 20px;
+}
+
+p:last-child {
+  margin-bottom: 0;
+}
+
+a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+table td,
+table th {
+  border: 1px solid var(--color-text);
+  padding: 5px;
+  text-align: left;
+}

--- a/gigsboat-eleventy-starter/_includes/layout.liquid
+++ b/gigsboat-eleventy-starter/_includes/layout.liquid
@@ -1,0 +1,29 @@
+---
+title: Public Speaking
+---
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>{{ title }}</title>
+    {% if description %}
+    <meta name="description" content="{{description}}" />
+    {% endif %}
+
+    <link rel="stylesheet" href="styles.css" />
+
+</head>
+
+<body>
+    <main>
+        {% block content %}
+        {{ content }}
+        {% endblock %}
+    </main>
+</body>
+
+</html>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -39,4 +39,4 @@ layout: layout
 
 <p align='center'><h1 align='center'>This will appear at the bottom of the generated README.md file</h1>
 
-<i>Updated on 2022-01-25T17:04:44.980Z</i>
+<i>Updated on 2022-01-26T12:45:15.791Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,0 +1,42 @@
+---
+title: This is the html page title
+description: This is the html page description
+layout: layout
+---
+<!-- DO NOT EDIT! THIS FILE WILL BE OVERRIDDEN BY THE GIGSBOAT SCRIPT -->
+<div align='center'><p><img src="https://img.shields.io/badge/total-1-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-1-red?style=flat-square" alt="Total Conferences">    </p>
+</div>
+  <p align='center'><h1 align='center'>This will appear at the top of the generated README.md file</h1>
+<p align='center'>Let's add some badges! <p align='center'><a href='https://twitter.com/liran_tal'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/liran_tal?style=social'></a></p>
+
+ - In addition to raw HTML elements, you can use format sections
+ - Using HTML elements to construct the output
+
+
+# Table of Contents
+
+
+ - [Year of 2021](#2021) - total events 1
+
+# 2021
+
+
+![Total Events](https://img.shields.io/badge/total-1-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)    
+
+
+<table>
+  <tr>
+    <td align="center"> <img src="https://pbs.twimg.com/media/E61MqWJXoAMJdHM?format=jpg&name=4096x4096" width="85" height="50" /> </td>
+  </tr>
+</table>
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2021-7-21 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](pages/2021/2021-01-01.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | IL | English |
+
+
+
+<p align='center'><h1 align='center'>This will appear at the bottom of the generated README.md file</h1>
+
+<i>Updated on 2022-01-25T17:04:44.980Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -39,4 +39,4 @@ layout: layout
 
 <p align='center'><h1 align='center'>This will appear at the bottom of the generated README.md file</h1>
 
-<i>Updated on 2022-01-26T12:45:15.791Z</i>
+<i>Updated on 2022-01-26T15:53:06.189Z</i>

--- a/gigsboat-eleventy-starter/styles.css
+++ b/gigsboat-eleventy-starter/styles.css
@@ -1,0 +1,65 @@
+:root {
+  --nightrider-gray: #333;
+  --white-smoke: #eee;
+  --blue: #0ff;
+  --cornflower-blue: #539bf5;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: var(--white-smoke);
+    --color-text: var(--nightrider-gray);
+    --color-link: var(--cornflower-blue);
+  }
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: var(--nightrider-gray);
+    --color-text: var(--white-smoke);
+    --color-link: var(--cornflower-blue);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, system-ui, sans-serif;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+}
+
+main {
+  max-width: calc(900px - (20px * 2));
+  margin: 0 auto;
+  padding-right: 20px;
+  padding-left: 20px;
+}
+
+p:last-child {
+  margin-bottom: 0;
+}
+
+a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+table td,
+table th {
+  border: 1px solid var(--color-text);
+  padding: 5px;
+  text-align: left;
+}

--- a/gigsboat.json
+++ b/gigsboat.json
@@ -27,5 +27,11 @@
     {
       "raw": "<p align='center'><h1 align='center'>This will appear at the bottom of the generated README.md file</h1>"
     }
-  ]
+  ],
+  "eleventy": {
+    "title": "This is the html page title",
+    "description": "This is the html page description",
+    "layout": "layout",
+    "inputDir": "gigsboat-eleventy-starter"
+  }
 }

--- a/gigsboat.json
+++ b/gigsboat.json
@@ -3,7 +3,12 @@
     "sourceDirectory": "pages"
   },
   "output": {
-    "markdownFile": "README-gigs.md"
+    "markdownFile": "gigsboat-eleventy-starter/index.md"
+  },
+  "metadata": {
+    "title": "This is the html page title",
+    "description": "This is the html page description",
+    "layout": "layout"
   },
   "preContent": [
     {
@@ -27,11 +32,5 @@
     {
       "raw": "<p align='center'><h1 align='center'>This will appear at the bottom of the generated README.md file</h1>"
     }
-  ],
-  "eleventy": {
-    "title": "This is the html page title",
-    "description": "This is the html page description",
-    "layout": "layout",
-    "inputDir": "gigsboat-eleventy-starter"
-  }
+  ]
 }


### PR DESCRIPTION
This PR complements [PR #30](https://github.com/gigsboat/cli/pull/30) for the cli

Please note the [eleventy workflow action](https://github.com/gigsboat/gigs-template/pull/3/files#diff-27a64559f857e4ee49c2d6b94fa1af6a9472b5017b3853015dc0ce6393f7d72d) has some temporary values in order to demonstrate functionality

I have added a super basic 11ty starter and config that can be edited, with new styles, liquid templates and plugins. But as is at the moment, the contents of the produced document are not configurable.

How it works:
When the [eleventy workflow action](https://github.com/gigsboat/gigs-template/pull/3/files#diff-27a64559f857e4ee49c2d6b94fa1af6a9472b5017b3853015dc0ce6393f7d72d) runs, it copies the original generated markdown file in the `gigsboat-eleventy-starter` directory adding some basic yaml metadata. In this metadata we define the layout template file. This liquid template file already exists in the `gigsboat-eleventy-starter` directory which also contains some very basic styles. Then using that directory, the eleventy script generates an HTML in a `docs` directory from which we can automatically deploy to github pages if desired. The output directory is configurable through the .eleventy.js file if we don't want it to be `docs`.